### PR TITLE
Add support for ucloud core hour billing products

### DIFF
--- a/src/main/kotlin/dk/aau/claaudia/openstackgateway/controllers/UcloudProviderController.kt
+++ b/src/main/kotlin/dk/aau/claaudia/openstackgateway/controllers/UcloudProviderController.kt
@@ -5,7 +5,6 @@ import dk.aau.claaudia.openstackgateway.config.UCloudProperties
 import dk.aau.claaudia.openstackgateway.services.OpenStackService
 import dk.sdu.cloud.CommonErrorMessage
 import dk.sdu.cloud.FindByStringId
-import dk.sdu.cloud.accounting.api.ProductReference
 import dk.sdu.cloud.app.orchestrator.api.*
 import dk.sdu.cloud.calls.BulkRequest
 import dk.sdu.cloud.calls.BulkResponse
@@ -80,36 +79,7 @@ class SimpleCompute(
         log.info("Retrieving products")
 
         val response = BulkResponse(
-            openstackService.listFlavors().filterNotNull().map { flavor ->
-                ComputeSupport(
-                    ProductReference(
-                        flavor.name,
-                        openstackService.getFlavorExtraSpecs(flavor.id).getOrDefault(
-                            "availability_zone", providerProperties.defaultProductCategory
-                        ),
-                        providerProperties.id
-                    ),
-                    ComputeSupport.Docker(
-                        enabled = false,
-                        web = false,
-                        vnc = false,
-                        logs = false,
-                        terminal = false,
-                        peers = false,
-                        timeExtension = false,
-                        utilization = false
-                    ),
-                    ComputeSupport.VirtualMachine(
-                        enabled = true,
-                        logs = false,
-                        vnc = false,
-                        terminal = false,
-                        suspension = false,
-                        timeExtension = false,
-                        utilization = false
-                    )
-                )
-            }
+            openstackService.retrieveProducts()
         )
 
         logger().info(response.toString())


### PR DESCRIPTION
This code adds a "-h" to product category if the name ends with "-h"

This should achieve this request by Dan:

Jeg kan også se at jeres at de nye -h varianter stadig ikke virker helt. Jeg har gravet mig frem til at den svarer tilbage med den forkerte produktkategori. Jeres provider har brug for at svare tilbage med -h i sin egen kategori, det er kategorien der bestemmer hvilken betalingsform den har. Det vil sige at følgende:
 
{
      "product": {
        "id": "uc-t4-2-h",
        "category": "uc-t4",
        "provider": "aau"
      },
      "docker": {
     …
      },
      "virtualMachine": {
     …
      }
    },
 
Skal laves om til:
 
{
      "product": {
        "id": "uc-t4-2-h",
        "category": "uc-t4-h",
        "provider": "aau"
      },
      "docker": {
     …
      },
      "virtualMachine": {
     …
      }
    },